### PR TITLE
Error al cargar xml de envio desde Facturas de proveedor

### DIFF
--- a/wizard/upload_xml.py
+++ b/wizard/upload_xml.py
@@ -471,7 +471,7 @@ class UploadXMLWizard(models.TransientModel):
         })
         if 'CdgItem' in data:
             if 'TpoCodigo' in data['CdgItem']:
-                if line['CdgItem']['TpoCodigo'] == 'ean13':
+                if data['CdgItem']['TpoCodigo'] == 'ean13':
                     product_id.barcode = data['CdgItem']['VlrCodigo']
                 else:
                     product_id.default_code = data['CdgItem']['VlrCodigo']
@@ -576,7 +576,7 @@ class UploadXMLWizard(models.TransientModel):
                 lines.append(self._prepare_line(dte['Detalle'], journal=journal_document_class_id.journal_id, type=data['type']))
             elif len(dte['Detalle']) > 0:
                 for line in dte['Detalle']:
-                    lines.append(self._prepare_line(line))
+                    lines.append(self._prepare_line(line, journal=journal_document_class_id.journal_id, type=data['type']))
             data['invoice_line_ids'] = lines
             inv = self.env['account.invoice'].create(data)
             monto_xml = float(dte['Encabezado']['Totales']['MntTotal'])


### PR DESCRIPTION
Al tratar de cargar un xml para crear la factura de compras a partir del xml se obtiene el siguiente error
![error](https://cloud.githubusercontent.com/assets/7775116/20363762/875b242e-ac0e-11e6-9d4e-25c4dc95cd59.png), revisando el codigo en el archivo upload_xml.py, funcion _prepare_line en la linea 507, los parametros de esa funcion no son opcionales sino requeridos, pero al llamar a esa funcion desde la linea 579, solo se pasa un parametro, no son pasado el journal y el type.

Creo que es necesario pasar esos parametros